### PR TITLE
View.propTypes deprecated as of RN 0.44. Replaced with ViewPropTypes …

### DIFF
--- a/src/fields/Separator.js
+++ b/src/fields/Separator.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-let { View, StyleSheet, Text} = require('react-native');
+let { View, StyleSheet, Text, ViewPropTypes} = require('react-native');
 
 export class Separator extends React.Component{
   render(){
@@ -18,7 +18,7 @@ export class Separator extends React.Component{
 
 Separator.propTypes = {
   labelStyle: Text.propTypes.style,
-  containerStyle: View.propTypes.style
+  containerStyle: ViewPropTypes.style
 }
 
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import ReactNative, { Platform } from 'react-native';
 import {Field} from './Field.js';
 
-const {View, StyleSheet, TextInput, Text} = ReactNative;
+const {View, StyleSheet, TextInput, Text, ViewPropTypes} = ReactNative;
 
 function validateEmail(email) {
   var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -208,5 +208,5 @@ export class InputComponent extends React.Component{
 InputComponent.propTypes = {
   labelStyle: Text.propTypes.style,
   inputStyle: TextInput.propTypes.style,
-  containerStyle: View.propTypes.style
+  containerStyle: ViewPropTypes.style
 }

--- a/src/lib/LinkComponent.js
+++ b/src/lib/LinkComponent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-let { View, StyleSheet, Text} = require('react-native');
+let { View, StyleSheet, Text, ViewPropTypes} = require('react-native');
 import {Field} from './Field';
 
 
@@ -48,5 +48,5 @@ export class LinkComponent extends React.Component{
 
 LinkComponent.propTypes = {
   labelStyle: Text.propTypes.style,
-  containerStyle: View.propTypes.style
+  containerStyle: ViewPropTypes.style
 }

--- a/src/lib/SwitchComponent.js
+++ b/src/lib/SwitchComponent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-let { View, StyleSheet, Text, Switch} = require('react-native');
+let { View, StyleSheet, Text, Switch, ViewPropTypes} = require('react-native');
 
 import {Field} from './Field';
 
@@ -53,7 +53,7 @@ export class SwitchComponent extends React.Component{
 
 SwitchComponent.propTypes = {
   labelStyle: Text.propTypes.style,
-  containerStyle: View.propTypes.style,
+  containerStyle: ViewPropTypes.style,
   switchStyle: Switch.propTypes.style
 }
 


### PR DESCRIPTION
…(imported from 'react-native')

Making the pull request on your (hans0low) open pull request since MichaelCereda appears to have quit updating the original. I needed to build on the changes you already made.